### PR TITLE
also generates documentation from .thrift file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,17 @@
               <goal>compile</goal>
             </goals>
           </execution>
+          <execution>
+            <id>thrift-docs</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <generator>html</generator>
+              <outputDirectory>${project.build.directory}/generated-docs</outputDirectory>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
Configured maven thrift plugin to also generate documentation using the built in html generator

Example documentation file: https://dev.evernote.com/doc/reference/
